### PR TITLE
Handling cases where queryParams are not always valid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,8 @@ lazy val coreUtils = (project in file("util-core")).
     crossScalaVersions := Seq("2.10.6"),
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-      "org.apache.commons" % "commons-lang3" % "3.4"
+      "org.apache.commons" % "commons-lang3" % "3.4",
+      "com.netaporter" %% "scala-uri" % "0.4.16"
     )
   )
 

--- a/util-core/src/main/scala/com/indix/utils/core/UrlUtils.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/UrlUtils.scala
@@ -1,11 +1,13 @@
 package com.indix.utils.core
 
-import java.net.{URI, URLDecoder,URLEncoder, URL}
+import java.net.{URI, URL, URLDecoder, URLEncoder}
 import java.util.{Map => JMap, TreeMap => JTreeMap}
+
+import com.netaporter.uri.Uri
+import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.text.WordUtils
 
 import scala.collection.JavaConversions._
-
 import scala.util.Try
 
 /** Useful helper methods to operate on product urls */
@@ -58,12 +60,10 @@ object UrlUtils {
     * @return URL query params(key-value pairs) as scala Map
     */
   def toQueryMap(url: String): Map[String, String] = {
-    val query = try {
-      Option(new URL(url).getQuery).getOrElse("")
-    } catch {
-      case e: Throwable => ""
-    }
-    queryStringMap(query)
+    Uri.parse(url).query
+      .filterParamsNames(StringUtils.isNotBlank)
+      .paramMap
+      .mapValues(_.mkString(","))
   }
 
   /**
@@ -101,16 +101,4 @@ object UrlUtils {
     * @return List of hash fragments from the url
     */
   def getHashFragments(url: String) = url.split("#").drop(1)
-
-  private def queryStringMap(query: String) = {
-    val parts = query.split("&")
-    parts.filter(_.nonEmpty).map {
-      p =>
-        val q = p.split("=")
-        q.length match {
-          case x if x > 1 => URLDecoder.decode(q(0), "UTF-8") -> URLDecoder.decode(q(1), "UTF-8")
-          case 1 => URLDecoder.decode(q(0), "UTF-8") -> ""
-        }
-    }.toMap
-  }
 }

--- a/util-core/src/main/scala/com/indix/utils/core/UrlUtils.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/UrlUtils.scala
@@ -108,7 +108,7 @@ object UrlUtils {
       p =>
         val q = p.split("=")
         q.length match {
-          case 2 => URLDecoder.decode(q(0), "UTF-8") -> URLDecoder.decode(q(1), "UTF-8")
+          case x if x > 1 => URLDecoder.decode(q(0), "UTF-8") -> URLDecoder.decode(q(1), "UTF-8")
           case 1 => URLDecoder.decode(q(0), "UTF-8") -> ""
         }
     }.toMap

--- a/util-core/src/test/scala/com/indix/utils/core/UrlUtilsSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/UrlUtilsSpec.scala
@@ -23,6 +23,11 @@ class UrlUtilsSpec extends FlatSpec {
 
     val resMap2 = UrlUtils.toQueryMap("http://google.com/")
     resMap2.size should be (0)
+
+    val resMap3 = UrlUtils.toQueryMap("http://uae.souq.com/ae-en/educational-book/national-park-service/english/a-19-1401/l/?ref=nav?ref=nav&page=23")
+    resMap3.size should be (2)
+    resMap3 should contain ("ref" -> "nav?ref")
+    resMap3 should contain ("page" -> "23")
   }
 
   "UrlUtils#isValid" should "return true/false given the url is valid" in {

--- a/util-core/src/test/scala/com/indix/utils/core/UrlUtilsSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/UrlUtilsSpec.scala
@@ -24,10 +24,11 @@ class UrlUtilsSpec extends FlatSpec {
     val resMap2 = UrlUtils.toQueryMap("http://google.com/")
     resMap2.size should be (0)
 
-    val resMap3 = UrlUtils.toQueryMap("http://uae.souq.com/ae-en/educational-book/national-park-service/english/a-19-1401/l/?ref=nav?ref=nav&page=23")
-    resMap3.size should be (2)
-    resMap3 should contain ("ref" -> "nav?ref")
+    val resMap3 = UrlUtils.toQueryMap("http://uae.souq.com/ae-en/educational-book/national-park-service/english/a-19-1401/l/?ref=nav?ref=nav&page=23&msg=foo%20bar")
+    resMap3.size should be (3)
+    resMap3 should contain ("ref" -> "nav?ref=nav")
     resMap3 should contain ("page" -> "23")
+    resMap3 should contain ("msg" -> "foo bar")
   }
 
   "UrlUtils#isValid" should "return true/false given the url is valid" in {


### PR DESCRIPTION
When we have more than 2 segments in the query params, just pick the first two and drop the remaining.

@manojlds This was the cause of failure of the MDA pipeline. 