### PR TITLE
Adding MPN blacklist, minor standardization changes

### DIFF
--- a/util-core/src/main/resources/BlacklistMPNs.txt
+++ b/util-core/src/main/resources/BlacklistMPNs.txt
@@ -1,19 +1,35 @@
 #na
+...
+as shown in image
+default
 do not apply
-doesnotapply
 does not apply
+doesnotapply
 dose not apply
+false
 generic
 model
 mpn:
 n/a
 na
+new
 no aplicable
 no mpn
 non applicabile
 non applicable
 none
+not
 not applicable
+null
 other
+others
+see options
+select your model using the list
+select your model using the menu
+selectdesiredmodel
+true
+unbranded
+unbranded/generic
+universal
 unknown
 various

--- a/util-core/src/main/resources/BlacklistMPNs.txt
+++ b/util-core/src/main/resources/BlacklistMPNs.txt
@@ -1,0 +1,19 @@
+#na
+do not apply
+doesnotapply
+does not apply
+dose not apply
+generic
+model
+mpn:
+n/a
+na
+no aplicable
+no mpn
+non applicabile
+non applicable
+none
+not applicable
+other
+unknown
+various

--- a/util-core/src/main/scala/com/indix/utils/core/MPN.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/MPN.scala
@@ -3,9 +3,11 @@ package com.indix.utils.core
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.text.WordUtils
 
+import scala.io.Source
+
 object MPN {
   // Some domain specific keywords known to be invalid
-  val BlackListedMpns = Set("unknown", "none", "does not apply", "non applicable", "na", "n/a", "various")
+  val BlackListedMpns = Source.fromInputStream(getClass.getResourceAsStream("/BlacklistMPNs.txt")).getLines.toSet
 
   val StopChars = Set(' ', '-', '_', '.', '/')
   val TerminateChars = Set(',', '"', '*', '%')
@@ -28,11 +30,11 @@ object MPN {
 
   def isValidIdentifier(value: String): Boolean = validateIdentifier(value)._1
 
-  // Does not consider numbers or one word strings as title-case phrase
+  // Does not consider one word strings as title-case phrase
   def isTitleCase(str: String): Boolean = {
     val words = str.split(' ').filter(_.nonEmpty)
     if (words.length < 2) false
-    else words.forall(w => w == WordUtils.capitalizeFully(w) && !StringUtils.isNumeric(w))
+    else words.forall(w => w == WordUtils.capitalizeFully(w))
   }
 
   def postProcessIdentifier(input: String): String = {

--- a/util-core/src/main/scala/com/indix/utils/core/MPN.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/MPN.scala
@@ -10,10 +10,22 @@ object MPN {
   val BlackListedMpns = Source.fromInputStream(getClass.getResourceAsStream("/BlacklistMPNs.txt")).getLines.toSet
 
   val StopChars = Set(' ', '-', '_', '.', '/')
-  val TerminateChars = Set(',', '"', '*', '%')
+  val TerminateChars = Set(',', '"', '*', '%', '{', '}', "#", '&', '\\')
 
   val MaxLen = 50
   val MinLen = 3
+
+  // Does not consider one word strings as title-case phrase
+  def isTitleCase(str: String): Boolean = {
+    val words = str.split(' ').filter(_.nonEmpty)
+    if (words.length < 2) false
+    else words.forall(w => w == WordUtils.capitalizeFully(w))
+  }
+
+  def postProcessIdentifier(input: String): String = {
+    val trimmedUpper = input.trim.toUpperCase
+    trimmedUpper
+  }
 
   // Check if identifier is valid, also return the identifier to process further if any
   def validateIdentifier(text: String): (Boolean, String) = {
@@ -30,22 +42,10 @@ object MPN {
 
   def isValidIdentifier(value: String): Boolean = validateIdentifier(value)._1
 
-  // Does not consider one word strings as title-case phrase
-  def isTitleCase(str: String): Boolean = {
-    val words = str.split(' ').filter(_.nonEmpty)
-    if (words.length < 2) false
-    else words.forall(w => w == WordUtils.capitalizeFully(w))
-  }
-
-  def postProcessIdentifier(input: String): String = {
-    val trimmedUpper = input.trim.toUpperCase
-    trimmedUpper
-  }
-
   def standardizeMPN(input: String): Option[String] = {
     val (isValid, identifier) = validateIdentifier(input)
     if (isValid) {
-      Some(postProcessIdentifier(input))
+      Some(postProcessIdentifier(identifier))
     } else if (StringUtils.isBlank(identifier)) {
       None
     } else if (identifier.indexWhere(c => TerminateChars.contains(c)) > 0) {

--- a/util-core/src/test/scala/com/indix/utils/core/MPNSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/MPNSpec.scala
@@ -35,11 +35,12 @@ class MPNSpec extends FlatSpec with Matchers {
   it should "standardize MPN" in {
     MPN.standardizeMPN(null) should be (None)
     MPN.standardizeMPN("Does not apply") should be (None)
-    MPN.standardizeMPN("PJS2V") should be (Some("PJS2V"))
     MPN.standardizeMPN("All Windows %22") should be (None)
     MPN.standardizeMPN("Samsung Galaxy Note 5") should be (None)
     MPN.standardizeMPN("A Square") should be (None)
+    MPN.standardizeMPN("{{availableProducts[0].sku}}") should be (None)
 
+    MPN.standardizeMPN("PJS2V") should be (Some("PJS2V"))
     MPN.standardizeMPN("30634190, 30753839, 31253006") should be (Some("30634190"))
     MPN.standardizeMPN("mr16r082gbn1-ck8 ") should be (Some("MR16R082GBN1-CK8"))
     MPN.standardizeMPN("SM-G950FZDAXSA") should be (Some("SM-G950FZDAXSA"))

--- a/util-core/src/test/scala/com/indix/utils/core/MPNSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/MPNSpec.scala
@@ -9,11 +9,13 @@ class MPNSpec extends FlatSpec with Matchers {
   it should "check title case" in {
     MPN.isTitleCase("Key Shell") should be(true)
     MPN.isTitleCase("Samsung Galaxy A8") should be(true)
+    MPN.isTitleCase("Samsung Galaxy Note 5") should be(true)
     MPN.isTitleCase("Tempered Glass") should be(true)
 
     MPN.isTitleCase("1442820G1") should be(false)
     MPN.isTitleCase("Macbook") should be(false)
     MPN.isTitleCase("CE 7200") should be(false)
+    MPN.isTitleCase("IPHONE") should be(false)
   }
 
   it should "validate identifier" in {
@@ -22,7 +24,6 @@ class MPNSpec extends FlatSpec with Matchers {
     MPN.isValidIdentifier("51") should be (false)
     MPN.isValidIdentifier("  NA   ") should be (false)
     MPN.isValidIdentifier("Does not apply") should be (false)
-
 
     MPN.isValidIdentifier("DT.VFGAA.003") should be (true)
     MPN.isValidIdentifier("A55BM-A/USB3") should be (true)
@@ -36,9 +37,12 @@ class MPNSpec extends FlatSpec with Matchers {
     MPN.standardizeMPN("Does not apply") should be (None)
     MPN.standardizeMPN("PJS2V") should be (Some("PJS2V"))
     MPN.standardizeMPN("All Windows %22") should be (None)
+    MPN.standardizeMPN("Samsung Galaxy Note 5") should be (None)
+    MPN.standardizeMPN("A Square") should be (None)
 
     MPN.standardizeMPN("30634190, 30753839, 31253006") should be (Some("30634190"))
     MPN.standardizeMPN("mr16r082gbn1-ck8 ") should be (Some("MR16R082GBN1-CK8"))
+    MPN.standardizeMPN("SM-G950FZDAXSA") should be (Some("SM-G950FZDAXSA"))
   }
 
 }


### PR DESCRIPTION
- Add blacklist as a resource file
- Model names like `Samsung Note 5` are invalid mpns