### PR TITLE
Converting valid GTIN (14-digit) to 13 digit EAN with zero padding upto 14 digits

### DIFF
--- a/util-core/src/main/scala/com/indix/utils/core/UPC.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/UPC.scala
@@ -17,14 +17,22 @@ object UPC {
     def standardizeRec(input: String) : String = {
       if (input.length < 12) {
         standardizeRec(leftPadZeroes(input, 12))
-      }
-      else if (input.length == 12) {
+      } else if (input.length == 12) {
         val cDigit = calculateCheckDigit(input.substring(0, 11))
         if (input.last == cDigit + '0' && !isIsbn(input)) {
           input
         } else {
           val cDigit13 = calculateCheckDigit(leftPadZeroes(input, 13))
           input + cDigit13
+        }
+      } else if (input.length == 14) {
+        val cDigit = calculateCheckDigit(input.substring(0, 13))
+        if(input.last == cDigit + '0') {
+          val gtinWithoutFirstAndCheckDigit = input.substring(1, 13)
+          val upcCheckDigit = calculateCheckDigit(gtinWithoutFirstAndCheckDigit)
+          standardizeRec(gtinWithoutFirstAndCheckDigit + upcCheckDigit)
+        } else {
+          fail("not a valid 14 digit UPC")
         }
       } else {
         input
@@ -47,13 +55,17 @@ object UPC {
   }
 
   private def calculateCheckDigit(input: String) = {
+    // We compute the odd and even positions from right to left because while computing check digit for EANs
+    // the input length would be an even number. This makes the even and odd positions change. While for
+    // input with odd length the even and odd positions are the same.
+    // Reference - https://en.wikipedia.org/wiki/Check_digit#EAN_(GLN,_GTIN,_EAN_numbers_administered_by_GS1)
 
-    val sumOddDigits = input.zipWithIndex
+    val sumOddDigits = input.reverse.zipWithIndex
       .filter { case (digit, index) => (index + 1) % 2 != 0 }
       .map { case (digit, index) => digit - '0' }
       .sum
 
-    val sumEvenDigits = input.zipWithIndex
+    val sumEvenDigits = input.reverse.zipWithIndex
       .filter { case (digit, index) => (index + 1) % 2 == 0 }
       .map { case (digit, index) => digit - '0' }
       .sum

--- a/util-core/src/test/scala/com/indix/utils/core/UPCSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/UPCSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class UPCSpec extends FlatSpec with Matchers {
 
-  it should "convert a UPC to a standardized format" in {
+  "UPC" should "convert a UPC to a standardized format" in {
     UPC.standardize("63938200039") should be("00639382000393")
     UPC.standardize("99999999623") should be("00999999996237")
     UPC.standardize("89504500098") should be("00895045000982")
@@ -23,6 +23,12 @@ class UPCSpec extends FlatSpec with Matchers {
     UPC.standardize("715660702866") should be("00715660702866")
   }
 
+  it should "work correctly for GTIN UPCs by converting it to a valid EAN-13 with padded zeros" in {
+    UPC.standardize("10010942220401") should be ("00010942220404")
+    UPC.standardize("47111850104013") should be("07111850104015")
+    UPC.standardize("40628043604719") should be("00628043604711")
+  }
+
 
   it should "work correctly for ISBN numbers" in {
     UPC.standardize("978052549832") should be("9780525498322")
@@ -33,6 +39,12 @@ class UPCSpec extends FlatSpec with Matchers {
 
   it should "not replace check-digit if UPC already left padded and check-digit and last-digit same" in {
     UPC.standardize("0753174052534") should be("00753174052534")
+  }
+
+  it should "fail for an invalid 14-digit UPC (GTIN)" in {
+    intercept[IllegalArgumentException] {
+      UPC.standardize("47111850104010")
+    }
   }
 
   it should "fail for all zeroes UPC" in {


### PR DESCRIPTION
Convert a valid GTIN to zero-padded EAN-13, which are most commonly found on upcitemdb and other stores. 	