### PR TITLE
Adding UPC.isValid

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 0.13.16

--- a/util-core/src/main/scala/com/indix/utils/core/UPC.scala
+++ b/util-core/src/main/scala/com/indix/utils/core/UPC.scala
@@ -6,6 +6,8 @@ import scala.util.Try
 
 object UPC {
 
+  def isValid(input: String) = Try(standardize(input)).map(_ == input).toOption.getOrElse(false)
+
   /**
     * Standardizes a UPC in the GTIN-14 format
     * If the given string is not a valid UPC, the method throws an `IllegalArgumentException`

--- a/util-core/src/test/scala/com/indix/utils/core/UPCSpec.scala
+++ b/util-core/src/test/scala/com/indix/utils/core/UPCSpec.scala
@@ -23,6 +23,14 @@ class UPCSpec extends FlatSpec with Matchers {
     UPC.standardize("715660702866") should be("00715660702866")
   }
 
+  it should "check if the input UPC is valid as checked by UPCItemDB" in {
+    UPC.isValid("0420160002247") should be(false)
+    UPC.isValid("000000010060") should be(false)
+    // the above same UPCs are validated after standardizing them
+    UPC.isValid(UPC.standardize("0420160002247")) should be(true)
+    UPC.isValid(UPC.standardize("000000010060")) should be(true)
+  }
+
   it should "work correctly for GTIN UPCs by converting it to a valid EAN-13 with padded zeros" in {
     UPC.standardize("10010942220401") should be ("00010942220404")
     UPC.standardize("47111850104013") should be("07111850104015")


### PR DESCRIPTION
Today our internal `isValidUPC` checks if the input can be standardized and if yes, it returns true. It creates a kind of confusion because the UPCs passing the validator isn't a valid upc on it's own until it is standardized. For this purpose, I've added a `UPC.isValid` here itself which checks if the input and the standardized version of the input is the same.

I feel this makes the contract of isValidUPC more clear and don't assume that someone downstream should standardize the upc before consuming them. 